### PR TITLE
Add Entry Type

### DIFF
--- a/LibArchive.Net/LibArchiveReader.cs
+++ b/LibArchive.Net/LibArchiveReader.cs
@@ -97,10 +97,14 @@ public class LibArchiveReader : SafeHandleZeroOrMinusOneIsInvalid
 
     public class Entry
     {
+        private const int AE_IFDIR = 0x4000;
+
         protected readonly IntPtr entry;
         protected readonly IntPtr archive;
+        private readonly int fileType;
 
         public string Name { get; }
+        public bool IsDirectory => fileType == AE_IFDIR;
         public FileStream Stream => new(archive);
 
         protected Entry(IntPtr entry, IntPtr archive)
@@ -108,6 +112,7 @@ public class LibArchiveReader : SafeHandleZeroOrMinusOneIsInvalid
             this.entry = entry;
             this.archive = archive;
             Name = Marshal.PtrToStringUTF8(archive_entry_pathname(entry)) ?? throw new ApplicationException("Unable to retrieve entry's pathname");
+            fileType = archive_entry_filetype(entry);
         }
 
         internal static Entry? Create(IntPtr entry, IntPtr archive)
@@ -190,6 +195,9 @@ public class LibArchiveReader : SafeHandleZeroOrMinusOneIsInvalid
 
     [DllImport("archive")]
     private static extern IntPtr archive_entry_pathname(IntPtr entry);
+
+    [DllImport("archive")]
+    private static extern int archive_entry_filetype(IntPtr entry);
 
     [DllImport("archive")]
     private static extern int archive_read_free(IntPtr a);

--- a/Test.LibArchive.Net/ReaderTests.cs
+++ b/Test.LibArchive.Net/ReaderTests.cs
@@ -30,13 +30,9 @@ public class SevenZipTests
     {
         using var lar = new LibArchiveReader("7ztest.7z");
 
-        var extracted = lar.Entries().Aggregate(new Dictionary<string, EntrySpec>(), (extracted, entry) =>
-        {
-            extracted[entry.Name] = ForEntry(entry);
-            return extracted;
-        });
+        var extracted = lar.Entries().ToDictionary(_ => _.Name, ToExtractedEntry);
 
-        Assert.That(extracted, Is.EquivalentTo(new Dictionary<string, EntrySpec>
+        Assert.That(extracted, Is.EquivalentTo(new Dictionary<string, ExtractedEntry>
         {
             { "subdir/", new(emptyHash, true) },
             { "empty", new(emptyHash, false) },
@@ -52,13 +48,9 @@ public class SevenZipTests
         var files = Enumerable.Range(1, 4).Select(n => $"rartest.part0000{n}.rar").ToArray();
         using var lar = new LibArchiveReader(files);
 
-        var extracted = lar.Entries().Aggregate(new Dictionary<string, EntrySpec>(), (extracted, entry) =>
-        {
-            extracted[entry.Name] = ForEntry(entry);
-            return extracted;
-        });
+        var extracted = lar.Entries().ToDictionary(_ => _.Name, ToExtractedEntry);
 
-        Assert.That(extracted, Is.EquivalentTo(new Dictionary<string, EntrySpec>
+        Assert.That(extracted, Is.EquivalentTo(new Dictionary<string, ExtractedEntry>
         {
             { "subdir", new(emptyHash, true) },
             { "empty", new(emptyHash, false) },
@@ -70,9 +62,9 @@ public class SevenZipTests
 
     #region Support code
 
-    private record EntrySpec(string ContentHash, bool IsDirectory);
+    private record ExtractedEntry(string ContentHash, bool IsDirectory);
 
-    private EntrySpec ForEntry(LibArchiveReader.Entry entry) =>
+    private ExtractedEntry ToExtractedEntry(LibArchiveReader.Entry entry) =>
         new(ContentHash(entry), entry.IsDirectory);
 
     private string ContentHash(LibArchiveReader.Entry entry)

--- a/Test.LibArchive.Net/ReaderTests.cs
+++ b/Test.LibArchive.Net/ReaderTests.cs
@@ -1,5 +1,4 @@
 using System.Security.Cryptography;
-using System.Text;
 using LibArchive.Net;
 using NUnit.Framework;
 
@@ -7,48 +6,78 @@ namespace Test.LibArchive.Net;
 
 public class SevenZipTests
 {
-    private readonly SHA256 hash = SHA256.Create();
-    
+    #region Setup and Tear Down
+
+    private readonly HashAlgorithm hasher;
+    private readonly string emptyHash;
+
+    public SevenZipTests()
+    {
+        hasher = SHA256.Create();
+        emptyHash = HashToString(hasher.ComputeHash(Array.Empty<byte>()));
+    }
+
     [OneTimeTearDownAttribute]
-      public void OneTimeTearDown() {
-        hash.Dispose();
-      }
+    public void OneTimeTearDown()
+    {
+        hasher.Dispose();
+    }
+
+    #endregion
 
     [Test]
     public void Test7z()
     {
         using var lar = new LibArchiveReader("7ztest.7z");
-        foreach (var e in lar.Entries())
+
+        var extracted = lar.Entries().Aggregate(new Dictionary<string, string>(), (extracted, entry) =>
         {
-            using var s = e.Stream;
-            StringBuilder sb = new(e.Name,e.Name.Length+33);
-            sb.Append(' ');
-            foreach (var d in hash.ComputeHash(s))
-            {
-                sb.Append(d.ToString("x2"));
-            }
-            Console.WriteLine(sb);
-        }
-        Assert.Pass();
+            extracted[entry.Name] = ContentHash(entry);
+            return extracted;
+        });
+
+        Assert.That(extracted, Is.EquivalentTo(new Dictionary<string, string>
+        {
+            { "subdir/", emptyHash },
+            { "empty", emptyHash },
+            { "subdir/empty", emptyHash },
+            { "1gzero", "49-BC-20-DF-15-E4-12-A6-44-72-42-1E-13-FE-86-FF-1C-51-65-E1-8B-2A-FC-CF-16-0D-4D-C1-9F-E6-8A-14" },
+            { "1krandom", "DA-26-F3-BE-7A-9A-2D-F1-0A-49-35-87-8B-18-C8-FF-FE-2B-96-13-EA-CD-E2-C8-67-DF-8A-A2-5D-41-0D-0A" },
+        }));
     }
 
     [Test]
     public void TestMultiRar()
     {
-        var files = Directory.GetFiles(TestContext.CurrentContext.TestDirectory, "rartest*.rar");
-        Array.Sort(files);
-        Assert.That(files, Has.Length.EqualTo(4), "Expected 4 RAR segments");
-        using var rar = new LibArchiveReader(files);
-        foreach (var e in rar.Entries())
+        var files = Enumerable.Range(1, 4).Select(n => $"rartest.part0000{n}.rar").ToArray();
+        using var lar = new LibArchiveReader(files);
+
+        var extracted = lar.Entries().Aggregate(new Dictionary<string, string>(), (extracted, entry) =>
         {
-            using var s = e.Stream;
-            StringBuilder sb = new(e.Name, e.Name.Length + 33);
-            sb.Append(' ');
-            foreach (var d in hash.ComputeHash(s))
-            {
-                sb.Append(d.ToString("x2"));
-            }
-            Console.WriteLine(sb);
-        }
+            extracted[entry.Name] = ContentHash(entry);
+            return extracted;
+        });
+
+        Assert.That(extracted, Is.EquivalentTo(new Dictionary<string, string>
+        {
+            { "subdir", emptyHash },
+            { "empty", emptyHash },
+            { "subdir/empty", emptyHash },
+            { "1gzero", "8B-A9-05-B1-20-A7-C8-D7-89-0F-AB-53-3B-75-65-C9-2C-3D-30-B7-E2-98-41-DF-52-C0-CF-F3-9D-3C-F1-A2" },
+            { "1krandom", "DA-26-F3-BE-7A-9A-2D-F1-0A-49-35-87-8B-18-C8-FF-FE-2B-96-13-EA-CD-E2-C8-67-DF-8A-A2-5D-41-0D-0A" },
+        }));
     }
+
+    #region Support code
+
+    private string ContentHash(LibArchiveReader.Entry entry)
+    {
+        using var stream = entry.Stream;
+        return HashToString(hasher.ComputeHash(stream));
+    }
+
+    private static string HashToString(byte[] hash) =>
+        BitConverter.ToString(hash);
+
+    #endregion
 }

--- a/Test.LibArchive.Net/ReaderTests.cs
+++ b/Test.LibArchive.Net/ReaderTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using LibArchive.Net;
 using NUnit.Framework;
+using static LibArchive.Net.LibArchiveReader;
 
 namespace Test.LibArchive.Net;
 
@@ -34,11 +35,11 @@ public class SevenZipTests
 
         Assert.That(extracted, Is.EquivalentTo(new Dictionary<string, ExtractedEntry>
         {
-            { "subdir/", new(emptyHash, true) },
-            { "empty", new(emptyHash, false) },
-            { "subdir/empty", new(emptyHash, false) },
-            { "1gzero", new("49-BC-20-DF-15-E4-12-A6-44-72-42-1E-13-FE-86-FF-1C-51-65-E1-8B-2A-FC-CF-16-0D-4D-C1-9F-E6-8A-14", false) },
-            { "1krandom", new("DA-26-F3-BE-7A-9A-2D-F1-0A-49-35-87-8B-18-C8-FF-FE-2B-96-13-EA-CD-E2-C8-67-DF-8A-A2-5D-41-0D-0A", false) },
+            { "subdir/", new(EntryType.Directory, emptyHash) },
+            { "empty", new(EntryType.RegularFile, emptyHash) },
+            { "subdir/empty", new(EntryType.RegularFile, emptyHash) },
+            { "1gzero", new(EntryType.RegularFile, "49-BC-20-DF-15-E4-12-A6-44-72-42-1E-13-FE-86-FF-1C-51-65-E1-8B-2A-FC-CF-16-0D-4D-C1-9F-E6-8A-14") },
+            { "1krandom", new(EntryType.RegularFile, "DA-26-F3-BE-7A-9A-2D-F1-0A-49-35-87-8B-18-C8-FF-FE-2B-96-13-EA-CD-E2-C8-67-DF-8A-A2-5D-41-0D-0A") },
         }));
     }
 
@@ -52,22 +53,22 @@ public class SevenZipTests
 
         Assert.That(extracted, Is.EquivalentTo(new Dictionary<string, ExtractedEntry>
         {
-            { "subdir", new(emptyHash, true) },
-            { "empty", new(emptyHash, false) },
-            { "subdir/empty", new(emptyHash, false) },
-            { "1gzero", new("8B-A9-05-B1-20-A7-C8-D7-89-0F-AB-53-3B-75-65-C9-2C-3D-30-B7-E2-98-41-DF-52-C0-CF-F3-9D-3C-F1-A2", false) },
-            { "1krandom", new("DA-26-F3-BE-7A-9A-2D-F1-0A-49-35-87-8B-18-C8-FF-FE-2B-96-13-EA-CD-E2-C8-67-DF-8A-A2-5D-41-0D-0A", false) },
+            { "subdir", new(EntryType.Directory, emptyHash) },
+            { "empty", new(EntryType.RegularFile, emptyHash) },
+            { "subdir/empty", new(EntryType.RegularFile, emptyHash) },
+            { "1gzero", new(EntryType.RegularFile, "8B-A9-05-B1-20-A7-C8-D7-89-0F-AB-53-3B-75-65-C9-2C-3D-30-B7-E2-98-41-DF-52-C0-CF-F3-9D-3C-F1-A2") },
+            { "1krandom", new(EntryType.RegularFile, "DA-26-F3-BE-7A-9A-2D-F1-0A-49-35-87-8B-18-C8-FF-FE-2B-96-13-EA-CD-E2-C8-67-DF-8A-A2-5D-41-0D-0A") },
         }));
     }
 
     #region Support code
 
-    private record ExtractedEntry(string ContentHash, bool IsDirectory);
+    private record ExtractedEntry(EntryType Type, string ContentHash);
 
-    private ExtractedEntry ToExtractedEntry(LibArchiveReader.Entry entry) =>
-        new(ContentHash(entry), entry.IsDirectory);
+    private ExtractedEntry ToExtractedEntry(Entry entry) =>
+        new(entry.Type, ContentHash(entry));
 
-    private string ContentHash(LibArchiveReader.Entry entry)
+    private string ContentHash(Entry entry)
     {
         using var stream = entry.Stream;
         return HashToString(hasher.ComputeHash(stream));

--- a/Test.LibArchive.Net/ReaderTests.cs
+++ b/Test.LibArchive.Net/ReaderTests.cs
@@ -30,19 +30,19 @@ public class SevenZipTests
     {
         using var lar = new LibArchiveReader("7ztest.7z");
 
-        var extracted = lar.Entries().Aggregate(new Dictionary<string, string>(), (extracted, entry) =>
+        var extracted = lar.Entries().Aggregate(new Dictionary<string, EntrySpec>(), (extracted, entry) =>
         {
-            extracted[entry.Name] = ContentHash(entry);
+            extracted[entry.Name] = ForEntry(entry);
             return extracted;
         });
 
-        Assert.That(extracted, Is.EquivalentTo(new Dictionary<string, string>
+        Assert.That(extracted, Is.EquivalentTo(new Dictionary<string, EntrySpec>
         {
-            { "subdir/", emptyHash },
-            { "empty", emptyHash },
-            { "subdir/empty", emptyHash },
-            { "1gzero", "49-BC-20-DF-15-E4-12-A6-44-72-42-1E-13-FE-86-FF-1C-51-65-E1-8B-2A-FC-CF-16-0D-4D-C1-9F-E6-8A-14" },
-            { "1krandom", "DA-26-F3-BE-7A-9A-2D-F1-0A-49-35-87-8B-18-C8-FF-FE-2B-96-13-EA-CD-E2-C8-67-DF-8A-A2-5D-41-0D-0A" },
+            { "subdir/", new(emptyHash, true) },
+            { "empty", new(emptyHash, false) },
+            { "subdir/empty", new(emptyHash, false) },
+            { "1gzero", new("49-BC-20-DF-15-E4-12-A6-44-72-42-1E-13-FE-86-FF-1C-51-65-E1-8B-2A-FC-CF-16-0D-4D-C1-9F-E6-8A-14", false) },
+            { "1krandom", new("DA-26-F3-BE-7A-9A-2D-F1-0A-49-35-87-8B-18-C8-FF-FE-2B-96-13-EA-CD-E2-C8-67-DF-8A-A2-5D-41-0D-0A", false) },
         }));
     }
 
@@ -52,23 +52,28 @@ public class SevenZipTests
         var files = Enumerable.Range(1, 4).Select(n => $"rartest.part0000{n}.rar").ToArray();
         using var lar = new LibArchiveReader(files);
 
-        var extracted = lar.Entries().Aggregate(new Dictionary<string, string>(), (extracted, entry) =>
+        var extracted = lar.Entries().Aggregate(new Dictionary<string, EntrySpec>(), (extracted, entry) =>
         {
-            extracted[entry.Name] = ContentHash(entry);
+            extracted[entry.Name] = ForEntry(entry);
             return extracted;
         });
 
-        Assert.That(extracted, Is.EquivalentTo(new Dictionary<string, string>
+        Assert.That(extracted, Is.EquivalentTo(new Dictionary<string, EntrySpec>
         {
-            { "subdir", emptyHash },
-            { "empty", emptyHash },
-            { "subdir/empty", emptyHash },
-            { "1gzero", "8B-A9-05-B1-20-A7-C8-D7-89-0F-AB-53-3B-75-65-C9-2C-3D-30-B7-E2-98-41-DF-52-C0-CF-F3-9D-3C-F1-A2" },
-            { "1krandom", "DA-26-F3-BE-7A-9A-2D-F1-0A-49-35-87-8B-18-C8-FF-FE-2B-96-13-EA-CD-E2-C8-67-DF-8A-A2-5D-41-0D-0A" },
+            { "subdir", new(emptyHash, true) },
+            { "empty", new(emptyHash, false) },
+            { "subdir/empty", new(emptyHash, false) },
+            { "1gzero", new("8B-A9-05-B1-20-A7-C8-D7-89-0F-AB-53-3B-75-65-C9-2C-3D-30-B7-E2-98-41-DF-52-C0-CF-F3-9D-3C-F1-A2", false) },
+            { "1krandom", new("DA-26-F3-BE-7A-9A-2D-F1-0A-49-35-87-8B-18-C8-FF-FE-2B-96-13-EA-CD-E2-C8-67-DF-8A-A2-5D-41-0D-0A", false) },
         }));
     }
 
     #region Support code
+
+    private record EntrySpec(string ContentHash, bool IsDirectory);
+
+    private EntrySpec ForEntry(LibArchiveReader.Entry entry) =>
+        new(ContentHash(entry), entry.IsDirectory);
 
     private string ContentHash(LibArchiveReader.Entry entry)
     {


### PR DESCRIPTION
Background: I'm considering switching from 7z to libarchive for a project of mine and I need to know the entry type.

- Adds the `Type` property to the `Entry` class. Only `RegularFile` and `Directory` are supported, as they are the only ones tested. Other types would return an enum with an int value without a label.
- Adds utility properties `IsDirectory` and `IsRegularFile` to the `Entry` class, covering the two most common elements (don't expect other types in the future to have their own property like these two).

Also in this PR:
- c9b6405d248fe562363f05c0521c74a4cc2dbb2e refactors tests to avoid having to compare hashes in build logs with known ones.
- fbb6adfc7ae6ad37fc386809a59c78aa4e46d3d0 by passing and storing the entry handle into the Entry object, it is possible to extend its functionality.
  - Some developers consider bad practice to throw exceptions in constructors. I considered it the best option compared to having `Name` nullable or calling "libarchive" methods in the `Create` factory, that would make it harder for users to extend `LibArchiveReader`.
  - `Entity.Create` hides the exception handling.
  - Since `ApplicationException`'s constructur takes a nullable parameter, I've removed the string interpolation in the `Throw()` method.

Moved into #83:
- ~8c6ae12e434263641fb59723d9aa570b54e9424c adds a `.gitignore` file from [GH's standard templates](https://github.com/github/gitignore)~.