### PR TITLE
Build test code under current SDK not legacy

### DIFF
--- a/Test.LibArchive.Net/Test.LibArchive.Net.csproj
+++ b/Test.LibArchive.Net/Test.LibArchive.Net.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net$(NETCoreAppMaximumVersion)</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
Automatically target .netX where X is the highest .Net major version supported by the SDK currently in use. One less chore.