### PR TITLE
Prep v0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+v0.3.1 - April 7, 2026
+
+**Native Library Updates:**
+- Bump libarchive from 3.8.4 to 3.8.6
+- Bump xz from 5.8.2 to 5.8.3
+- Bump zlib from 1.3.1 to 1.3.2
+- Bump libxml2 from 2.15.1 to 2.15.2
+
+**Build & CI Improvements:**
+- Add SHA256 checksum verification for native dependency downloads
+- Reduce MSBuild message verbosity for native library copy
+- Direct sccache invocation for faster builds
+- Fix CI triggering for auto-created dependency PRs
+
+**Tooling Updates:**
+- Bump MinVer from 6.0.0 to 7.0.0
+- Bump NUnit from 4.4.0 to 4.5.1
+- Bump NUnit3TestAdapter from 6.0.1 to 6.2.0
+- Bump NUnit.Analyzers from 4.11.2 to 4.12.0
+- Bump Microsoft.NET.Test.Sdk from 18.0.1 to 18.4.0
+- Bump coverlet.collector from 6.0.4 to 8.0.1
+
 v0.3.0 - December 22, 2025
 
 **Archive Write Support:**

--- a/Test.LibArchive.Net/Test.LibArchive.Net.csproj
+++ b/Test.LibArchive.Net/Test.LibArchive.Net.csproj
@@ -11,7 +11,7 @@
         <UseTestingPlatform>true</UseTestingPlatform>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="NUnit" Version="4.5.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />


### PR DESCRIPTION
## Summary
- Add CHANGELOG entry for v0.3.1 covering all changes since v0.3.0
- Bump Microsoft.NET.Test.Sdk from 18.3.0 to 18.4.0 (only outdated dependency)

## Changes since v0.3.0
- Native lib bumps: libarchive 3.8.6, xz 5.8.3, zlib 1.3.2, libxml2 2.15.2
- Build/CI: SHA256 checksum verification, sccache, CI trigger fixes
- Tooling: MinVer 7.0.0, NUnit 4.5.1, coverlet 8.0.1, and more

## Test plan
- [ ] CI build passes on all platforms
- [ ] After merge, tag `v0.3.1` to trigger release

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR prepares for the v0.3.1 release by adding a comprehensive CHANGELOG entry documenting all changes since v0.3.0 (including native library updates, build improvements, and tooling updates) and bumping `Microsoft.NET.Test.Sdk` from 18.3.0 to 18.4.0, which was the only outdated dependency.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHANGELOG.md` |
| 2 | `Test.LibArchive.Net/Test.LibArchive.Net.csproj` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the v0.3.1 release by adding the CHANGELOG and bumping `Microsoft.NET.Test.Sdk` to 18.4.0. The release notes cover native library updates, build/CI improvements, and tooling bumps since v0.3.0.

<sup>Written for commit 05547cb67159cae4c43128ae3bcc465e9beab266. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

