### PR TITLE
Update file permission handling in `GetUnixPermissions` method

### DIFF
--- a/LibArchive.Net/LibArchiveWriter.Entries.cs
+++ b/LibArchive.Net/LibArchiveWriter.Entries.cs
@@ -40,7 +40,7 @@ public partial class LibArchiveWriter
         if (data == null)
             throw new ArgumentNullException(nameof(data));
 
-        WriteEntry(archivePath, data.Length, modificationTime ?? DateTime.UtcNow, 0644, stream =>
+        WriteEntry(archivePath, data.Length, modificationTime ?? DateTime.UtcNow, 420, stream =>
         {
             unsafe
             {
@@ -82,7 +82,7 @@ public partial class LibArchiveWriter
             using var pathBuffer = new SafeStringBuffer(archivePath);
             archive_entry_set_pathname(entry, pathBuffer.Ptr);
             archive_entry_set_filetype(entry, AE_IFDIR);
-            archive_entry_set_perm(entry, 0755); // rwxr-xr-x
+            archive_entry_set_perm(entry, 493); // rwxr-xr-x
             archive_entry_set_size(entry, 0);
 
             var (seconds, nanoseconds) = ToUnixTime(DateTime.UtcNow);
@@ -496,7 +496,9 @@ public partial class LibArchiveWriter
         // TODO: On Unix platforms, could use Mono.Unix or P/Invoke to get actual permissions
         // For now, use sensible defaults
 #if NET7_0_OR_GREATER
-        permissions = (int)fileInfo.UnixFileMode;
+        int uperm = (int)fileInfo.UnixFileMode;
+        if(uperm != -1 && uperm != 0)
+            permissions = uperm;
 #endif
 
         return permissions;

--- a/LibArchive.Net/LibArchiveWriter.Entries.cs
+++ b/LibArchive.Net/LibArchiveWriter.Entries.cs
@@ -483,14 +483,21 @@ public partial class LibArchiveWriter
     private static int GetUnixPermissions(FileInfo fileInfo)
     {
         // Default: rw-r--r-- (0644) for files
-        int permissions = 0644;
+        // This is a bitwise OR of the following:
+        // S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
+        int permissions = 420;
 
         // If read-only, remove write permissions
         if (fileInfo.Attributes.HasFlag(FileAttributes.ReadOnly))
-            permissions = 0444;
+            // This is a bitwise OR of the following:
+            // S_IRUSR | S_IRGRP | S_IROTH
+            permissions = 292;
 
         // TODO: On Unix platforms, could use Mono.Unix or P/Invoke to get actual permissions
         // For now, use sensible defaults
+#if NET7_0_OR_GREATER
+        permissions = (int)fileInfo.UnixFileMode;
+#endif
 
         return permissions;
     }


### PR DESCRIPTION
## Summary
Update default permissions on LibArchiveWriter

## Changes
- Default permissions defaults were wrong, i fixed it with the correct values.
- Also added `FileInfo.UnixFileMode` permissions on .net7+

## Testing
- [x] Tests pass locally
- [x] New tests added (if applicable)
- [x] Documentation updated (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] No new warnings introduced
- [x] Commit messages are descriptive

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes incorrect Unix file permission handling in the `GetUnixPermissions` method by converting octal notation (0644, 0444) to proper decimal values (420, 292) and adds support for .NET 7+ to use the native `UnixFileMode` property from `FileInfo` when available.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `LibArchive.Net/LibArchiveWriter.Entries.cs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Unix permission handling in `LibArchiveWriter` so files and directories get correct defaults and real modes on .NET 7+, with safe fallbacks when `UnixFileMode` is 0 (Windows) or -1 (missing).

- **Bug Fixes**
  - Use correct file defaults: rw-r--r-- (0644) and read-only: r--r--r-- (0444).
  - Set directory default to rwxr-xr-x (0755).
  - On .NET 7+, use `FileInfo.UnixFileMode` when non-zero and not -1; otherwise fall back to defaults.

<sup>Written for commit a1b8d56aa614058dcf0ea82bfc1749119166ed1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

