### PR TITLE
Fix Unix permission bug and adopt UnixFileMode (closes #220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v0.3.2 - unreleased
+
+**Bug Fixes:**
+- Fix incorrect Unix permission defaults in `LibArchiveWriter` — bare `0644`/`0755`/`0444` literals were being interpreted as decimal in C# (no octal literal syntax), producing nonsensical permission bits. Files now correctly default to `rw-r--r--` (and `r--r--r--` for read-only attributes), directories to `rwxr-xr-x`. Reported and initial fix contributed by @JuanCalle1606 in #220.
+
+**API Improvements:**
+- `LibArchiveWriter.GetUnixPermissions` now returns `System.IO.UnixFileMode` and uses `FileInfo.UnixFileMode` directly on .NET 7+, falling back to defaults when the platform reports `0` (Windows) or `-1` (file missing). On .NET Standard 2.0 an internal `UnixFileMode` polyfill mirrors the BCL flags enum so the same code paths and constants are used everywhere.
+
 v0.3.1 - April 7, 2026
 
 **Native Library Updates:**

--- a/LibArchive.Net/LibArchiveWriter.Entries.cs
+++ b/LibArchive.Net/LibArchiveWriter.Entries.cs
@@ -40,7 +40,7 @@ public partial class LibArchiveWriter
         if (data == null)
             throw new ArgumentNullException(nameof(data));
 
-        WriteEntry(archivePath, data.Length, modificationTime ?? DateTime.UtcNow, 0644, stream =>
+        WriteEntry(archivePath, data.Length, modificationTime ?? DateTime.UtcNow, DefaultFileMode, stream =>
         {
             unsafe
             {
@@ -82,7 +82,7 @@ public partial class LibArchiveWriter
             using var pathBuffer = new SafeStringBuffer(archivePath);
             archive_entry_set_pathname(entry, pathBuffer.Ptr);
             archive_entry_set_filetype(entry, AE_IFDIR);
-            archive_entry_set_perm(entry, 0755); // rwxr-xr-x
+            archive_entry_set_perm(entry, DefaultDirectoryMode);
             archive_entry_set_size(entry, 0);
 
             var (seconds, nanoseconds) = ToUnixTime(DateTime.UtcNow);
@@ -452,7 +452,7 @@ public partial class LibArchiveWriter
         archive_entry_set_mtime(entry, seconds, nanoseconds);
     }
 
-    private void WriteEntry(string archivePath, long size, DateTime modificationTime, int permissions, Action<Stream> writeData)
+    private void WriteEntry(string archivePath, long size, DateTime modificationTime, UnixFileMode permissions, Action<Stream> writeData)
     {
         var entry = archive_entry_new();
         try
@@ -480,19 +480,33 @@ public partial class LibArchiveWriter
         }
     }
 
-    private static int GetUnixPermissions(FileInfo fileInfo)
+    // rw-r--r--
+    private const UnixFileMode DefaultFileMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite |
+        UnixFileMode.GroupRead | UnixFileMode.OtherRead;
+
+    // r--r--r--
+    private const UnixFileMode ReadOnlyFileMode =
+        UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
+
+    // rwxr-xr-x
+    private const UnixFileMode DefaultDirectoryMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+        UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+        UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+
+    private static UnixFileMode GetUnixPermissions(FileInfo fileInfo)
     {
-        // Default: rw-r--r-- (0644) for files
-        int permissions = 0644;
-
-        // If read-only, remove write permissions
-        if (fileInfo.Attributes.HasFlag(FileAttributes.ReadOnly))
-            permissions = 0444;
-
-        // TODO: On Unix platforms, could use Mono.Unix or P/Invoke to get actual permissions
-        // For now, use sensible defaults
-
-        return permissions;
+#if NET7_0_OR_GREATER
+        // FileInfo.UnixFileMode returns 0 on non-Unix systems and (UnixFileMode)(-1)
+        // when the file does not exist; fall back to defaults in either case.
+        var mode = fileInfo.UnixFileMode;
+        if (mode != 0 && mode != (UnixFileMode)(-1))
+            return mode;
+#endif
+        return fileInfo.Attributes.HasFlag(FileAttributes.ReadOnly)
+            ? ReadOnlyFileMode
+            : DefaultFileMode;
     }
 
     private static (long seconds, long nanoseconds) ToUnixTime(DateTime dateTime)

--- a/LibArchive.Net/LibArchiveWriter.cs
+++ b/LibArchive.Net/LibArchiveWriter.cs
@@ -556,6 +556,9 @@ public partial class LibArchiveWriter : SafeHandleZeroOrMinusOneIsInvalid
     [LibraryImport("archive")]
     private static partial void archive_entry_set_perm(IntPtr entry, int perm);
 
+    private static void archive_entry_set_perm(IntPtr entry, UnixFileMode perm)
+        => archive_entry_set_perm(entry, (int)perm);
+
     [LibraryImport("archive")]
     private static partial void archive_entry_set_mtime(IntPtr entry, long sec, long nsec);
 #else
@@ -576,6 +579,9 @@ public partial class LibArchiveWriter : SafeHandleZeroOrMinusOneIsInvalid
 
     [DllImport("archive")]
     private static extern void archive_entry_set_perm(IntPtr entry, int perm);
+
+    private static void archive_entry_set_perm(IntPtr entry, UnixFileMode perm)
+        => archive_entry_set_perm(entry, (int)perm);
 
     [DllImport("archive")]
     private static extern void archive_entry_set_mtime(IntPtr entry, long sec, long nsec);

--- a/LibArchive.Net/UnixFileModePolyfill.cs
+++ b/LibArchive.Net/UnixFileModePolyfill.cs
@@ -1,0 +1,27 @@
+#if !NET7_0_OR_GREATER
+using System;
+
+namespace System.IO;
+
+/// <summary>
+/// Polyfill of <c>System.IO.UnixFileMode</c> for target frameworks that predate .NET 7.
+/// Values match the Unix mode_t bits so they can be passed directly to libarchive.
+/// </summary>
+[Flags]
+internal enum UnixFileMode
+{
+    None = 0,
+    OtherExecute = 1,
+    OtherWrite = 2,
+    OtherRead = 4,
+    GroupExecute = 8,
+    GroupWrite = 16,
+    GroupRead = 32,
+    UserExecute = 64,
+    UserWrite = 128,
+    UserRead = 256,
+    StickyBit = 512,
+    SetGroup = 1024,
+    SetUser = 2048,
+}
+#endif


### PR DESCRIPTION
## Summary
- Fixes the bug found by @JuanCalle1606 in #220: bare `0644`/`0755`/`0444` literals in `LibArchiveWriter` were decimal (C# has no octal literal syntax), producing wrong Unix permission bits.
- Replaces those literals with named `UnixFileMode` flag combinations.
- On .NET 7+ uses `FileInfo.UnixFileMode` directly (with fallback when it reports `0` on Windows or `-1` for missing files).
- On `netstandard2.0` ships an internal `UnixFileMode` polyfill mirroring the BCL flags enum so the same constants and code paths apply on every TFM.
- Adds a `UnixFileMode`-typed overload of `archive_entry_set_perm` so call sites read naturally.

Closes #220. Credits to @JuanCalle1606 in CHANGELOG and via `Co-authored-by` trailer.

## Test plan
- [x] `dotnet build` clean across `netstandard2.0`, `net8.0`, `net9.0`, `net10.0`
- [ ] CI green (native libs only available on CI for tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect Unix permission bits in `LibArchiveWriter` and adopts `UnixFileMode` for consistent, readable permission handling across platforms. Files and directories now default to the right modes, closing #220.

- **Bug Fixes**
  - Replaced decimal `0644`/`0755`/`0444` literals with `UnixFileMode` flags to fix wrong permission bits.
  - Defaults: files `rw-r--r--` (read-only -> `r--r--r--`); directories `rwxr-xr-x`.

- **Refactors**
  - `GetUnixPermissions` now returns `System.IO.UnixFileMode`; on .NET 7+ it uses `FileInfo.UnixFileMode` with fallback when it reports 0 (Windows) or -1 (missing).
  - Added a `UnixFileMode` overload for `archive_entry_set_perm` and an internal polyfill on `netstandard2.0` so the same flags and code paths work on all TFMs.

<sup>Written for commit 9e53f4e08d178e552f02c98412a71bf8173538be. Summary will update on new commits. <a href="https://cubic.dev/pr/jas88/libarchive.net/pull/225?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

