### PR TITLE
Pin all GitHub Actions to exact versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,23 +19,23 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
       - name: Cache library downloads
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/downloads
           key: library-downloads-${{ hashFiles('native/build-config.sh') }}
           restore-keys: |
             library-downloads-
       - name: Cache configure results
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/config-cache
           key: config-cache-macos-${{ hashFiles('native/build-*.sh') }}
           restore-keys: |
             config-cache-macos-
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: macos-build-v2
         env:
@@ -54,7 +54,7 @@ jobs:
           echo "=== ccache stats after build ==="
           ccache -s
       - name: Archive MacOS library
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: maclib
           path: ~/libarchive-native/libarchive.dylib
@@ -66,18 +66,18 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - name: Cache library downloads
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/downloads
           key: library-downloads-${{ hashFiles('native/build-config.sh') }}
           restore-keys: |
             library-downloads-
       - name: Cache configure results
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/config-cache
           key: config-cache-linux-${{ hashFiles('native/build-*.sh') }}
@@ -103,7 +103,7 @@ jobs:
           version: 1.0
           execute_install_scripts: true
       - name: Retrieve MacOS library
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: maclib
       - name: Install LLVM-MinGW for ARM64
@@ -118,7 +118,7 @@ jobs:
       - name: Update Directory.Build.props for SDK version
         run: ./scripts/generate-build-props.sh
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: all-native-builds-v2
           variant: sccache
@@ -212,7 +212,7 @@ jobs:
           echo "=== sccache stats after Linux builds ==="
           sccache --show-stats
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v4.35.2
         with:
           languages: 'csharp'
           build-mode: manual
@@ -270,7 +270,7 @@ jobs:
       - name: Cleanup build artifacts
         run: rm -rf local {bzip2,libarchive,libxml2,lz4,lzo,xz,zlib,zstd}-* x86-64--musl--stable-*
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v4.35.2
       - name: Upload built packages
         uses: svenstaro/upload-release-action@2.11.5
         if: contains(github.ref, 'refs/tags/v')
@@ -281,7 +281,7 @@ jobs:
           overwrite: true
           file_glob: true
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: dist
           path: |

--- a/.github/workflows/check-native-dependencies.yml
+++ b/.github/workflows/check-native-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
## Summary
Replaces every major-only floating action tag with the current exact patch release, matching the convention already used for `actions/setup-dotnet@v5.2.0`, `awalsh128/cache-apt-pkgs-action@v1.6.0`, and `svenstaro/upload-release-action@2.11.5`.

Also bumps `hendrikmuhs/ccache-action` from the frozen `@v1.2` tag (28 commits behind) to `@v1.2.23`. Upstream releases everything as `v1.2.X` without ever advancing the major.minor, which left the bare `v1.2` ref stuck without a path for Dependabot to update it.

## Why
- **Reproducibility** — builds bind to a tagged version rather than shifting whenever upstream re-points a major tag.
- **Dependabot visibility** — every upstream release now lands as a Dependabot PR with the release notes attached, instead of silent moves under floating tags.
- **Uniform style** — the workflow file is no longer a mix of major-only and exact pins.

| Action | Was | Now |
| --- | --- | --- |
| `actions/cache` | `v5` | `v5.0.5` |
| `actions/checkout` | `v6` | `v6.0.2` |
| `actions/download-artifact` | `v8` | `v8.0.1` |
| `actions/upload-artifact` | `v7` | `v7.0.1` |
| `github/codeql-action/{init,analyze}` | `v4` | `v4.35.2` |
| `hendrikmuhs/ccache-action` | `v1.2` | `v1.2.23` |

## Test plan
- [ ] CI green on this PR (build runs end-to-end with the pinned versions)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned all GitHub Actions to exact patch versions to make CI reproducible and enable clear Dependabot updates. Also updated `hendrikmuhs/ccache-action` from `v1.2` to `v1.2.23` to unstick version updates.

- **Dependencies**
  - Replaced floating tags with exact versions: `actions/checkout@v6.0.2`, `actions/cache@v5.0.5`, `actions/download-artifact@v8.0.1`, `actions/upload-artifact@v7.0.1`, `github/codeql-action/init@v4.35.2`, `github/codeql-action/analyze@v4.35.2`, `hendrikmuhs/ccache-action@v1.2.23`.
  - Benefits: reproducible builds and Dependabot PRs for each upstream release.

<sup>Written for commit 22429f7767620d022f91f72790618b60afd2e76c. Summary will update on new commits. <a href="https://cubic.dev/pr/jas88/libarchive.net/pull/226?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

