### PR TITLE
Fall back to ftp.gnu.org when ftpmirror.gnu.org serves a bad file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,10 +131,27 @@ jobs:
       - name: Install autoconf and automake
         run: |
           # xz 5.8.2 was built with automake 1.18.1 and autoconf 2.72
-          # Download to files and verify checksums (allows HTTP mirror redirects)
+          # Download with checksum verification; fall back to canonical ftp.gnu.org
+          # if a mirror serves a bad/corrupt file.
+          fetch_gnu() {
+            local path="$1" sha="$2" out="$3"
+            for url in "https://ftpmirror.gnu.org/gnu/$path" "https://ftp.gnu.org/gnu/$path"; do
+              echo "Fetching $url"
+              curl -fsSL --retry 3 --retry-delay 5 "$url" -o "$out" || continue
+              if echo "$sha  $out" | sha256sum -c --status; then
+                echo "Checksum OK from $url"
+                return 0
+              fi
+              echo "Checksum mismatch from $url, trying next source"
+              rm -f "$out"
+            done
+            echo "All sources failed for $path" >&2
+            return 1
+          }
           # Install autoconf 2.72
-          curl -sSL --retry 3 --retry-delay 5 https://ftpmirror.gnu.org/gnu/autoconf/autoconf-2.72.tar.xz -o autoconf-2.72.tar.xz
-          echo "ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a  autoconf-2.72.tar.xz" | sha256sum -c
+          fetch_gnu autoconf/autoconf-2.72.tar.xz \
+            ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a \
+            autoconf-2.72.tar.xz
           tar xJf autoconf-2.72.tar.xz
           cd autoconf-2.72
           ./configure --prefix=$HOME/.local
@@ -142,8 +159,9 @@ jobs:
           make install
           cd ..
           # Install automake 1.18.1 (exact version used to build xz 5.8.2)
-          curl -sSL --retry 3 --retry-delay 5 https://ftpmirror.gnu.org/gnu/automake/automake-1.18.1.tar.xz -o automake-1.18.1.tar.xz
-          echo "168aa363278351b89af56684448f525a5bce5079d0b6842bd910fdd3f1646887  automake-1.18.1.tar.xz" | sha256sum -c
+          fetch_gnu automake/automake-1.18.1.tar.xz \
+            168aa363278351b89af56684448f525a5bce5079d0b6842bd910fdd3f1646887 \
+            automake-1.18.1.tar.xz
           tar xJf automake-1.18.1.tar.xz
           cd automake-1.18.1
           ./configure --prefix=$HOME/.local


### PR DESCRIPTION
## Summary
- `ftpmirror.gnu.org` redirects to a random mirror; one occasionally serves a corrupt or unrelated file. Recent CI failure on PR #229 (and others) was an autoconf-2.72.tar.xz sha256 mismatch.
- Wrap the autoconf/automake fetches in a helper that retries the canonical `ftp.gnu.org` source on HTTP failure or checksum mismatch.
- Use `curl -f` so HTTP error pages are not saved as the artifact and then fed to `tar`.

## Test plan
- [ ] CI passes on this PR (downloads succeed via `ftpmirror.gnu.org`, normal path).
- [ ] Re-run a previously-failing build (e.g. PR #229) after merge — should no longer fail on the autoconf checksum.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a robust GNU source fetch in CI to stop flaky checksum failures by falling back to `https://ftp.gnu.org` when `https://ftpmirror.gnu.org` serves a bad file. Also use `curl -f` so HTTP error pages aren’t saved and fed to `tar`.

- **Bug Fixes**
  - Added `fetch_gnu()` in `.github/workflows/build.yml` that tries `ftpmirror.gnu.org` first, then `ftp.gnu.org`, verifies SHA-256, and retries on failure.
  - Switched to `curl -fsSL` with retries and removed bad artifacts on checksum mismatch.
  - Stabilizes downloads for autoconf 2.72 and automake 1.18.1; resolves CI checksum failures seen in builds like PR #229.

<sup>Written for commit e5bc05588a00d7683ee6228c80ec6d213fc3882d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

