### PR TITLE
Fix macOS build failure from libtool version mismatch

### DIFF
--- a/Test.LibArchive.Net/WriterTests.cs
+++ b/Test.LibArchive.Net/WriterTests.cs
@@ -277,7 +277,7 @@ public class WriterTests
         var archivePath = Path.Combine(testDirectory, "progress.zip");
         var progressReports = new List<FileProgress>();
 
-        var progress = new Progress<FileProgress>(p => progressReports.Add(p));
+        var progress = new SynchronousProgress<FileProgress>(p => progressReports.Add(p));
 
         using (var writer = new LibArchiveWriter(archivePath, ArchiveFormat.Zip))
         {
@@ -288,6 +288,26 @@ public class WriterTests
         Assert.That(progressReports, Is.Not.Empty);
         Assert.That(progressReports.Last().IsComplete, Is.True);
         Assert.That(progressReports.Last().PercentComplete, Is.EqualTo(100).Within(0.1));
+    }
+
+    /// <summary>
+    /// Invokes the handler inline on the reporting thread.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Progress{T}"/> is deliberately asynchronous: it marshals callbacks to the
+    /// captured <see cref="System.Threading.SynchronizationContext"/>, or posts them to the
+    /// ThreadPool when there is none, as is the case under NUnit. Reports therefore arrive
+    /// after the assertions have already run, and the handler would be mutating a
+    /// non-thread-safe <see cref="List{T}"/> from pool threads. Reporting inline keeps the
+    /// assertions deterministic while still exercising the library's IProgress contract.
+    /// </remarks>
+    private sealed class SynchronousProgress<T> : IProgress<T>
+    {
+        private readonly Action<T> handler;
+
+        public SynchronousProgress(Action<T> handler) => this.handler = handler;
+
+        public void Report(T value) => handler(value);
     }
 
     #endregion

--- a/native/build-config.sh
+++ b/native/build-config.sh
@@ -222,6 +222,14 @@ download_toolchain() {
 # Stamping the files in dependency order keeps the tarball's own generated files
 # and stops any rebuild rule from firing, so neither the host automake version
 # nor the host libtool version can affect the build.
+# Timestamp for stamping tier N, as a touch -t argument. Tiers are one minute
+# apart: make compares mtimes at second granularity, so a whole minute between
+# tiers leaves no room for two tiers to be seen as equal. The day itself is
+# arbitrary - only the relative order matters - and is overridable for testing.
+autotools_stamp_tier() {
+    printf '%s%02d%02d' "${AUTOTOOLS_STAMP_DAY:-20200101}" "$(($1 / 60))" "$(($1 % 60))"
+}
+
 normalize_autotools_timestamps() {
     local dir="$1"
     [ -d "$dir" ] || return 0
@@ -229,15 +237,23 @@ normalize_autotools_timestamps() {
 
     echo "Normalising autotools timestamps in ${dir}..."
 
-    # Oldest -> newest, matching the autotools dependency graph:
-    #   configure.ac/Makefile.am/m4 -> aclocal.m4 -> configure -> config.h.in -> Makefile.in
+    # Applied oldest -> newest. The ascending tier numbers are the contract: they
+    # mirror the autotools dependency graph, so a new file class must be inserted
+    # at the tier its dependencies require, not appended.
+    #
+    #   0 sources (configure.ac/Makefile.am/m4)
+    #   1 aclocal.m4      depends on tier 0
+    #   2 configure       depends on tiers 0-1
+    #   3 config.h.in     depends on tiers 0-1, and must not predate configure
+    #   4 Makefile.in     depends on tiers 0-1
     find "$dir" \( -name 'configure.ac' -o -name 'configure.in' -o -name 'Makefile.am' \
-        -o \( -name '*.m4' -a ! -name 'aclocal.m4' \) \) -exec touch -t 202001010000 {} +
-    find "$dir" -name 'aclocal.m4'  -exec touch -t 202001010001 {} +
-    find "$dir" -name 'configure'   -exec touch -t 202001010002 {} +
+        -o \( -name '*.m4' -a ! -name 'aclocal.m4' \) \) \
+        -exec touch -t "$(autotools_stamp_tier 0)" {} +
+    find "$dir" -name 'aclocal.m4' -exec touch -t "$(autotools_stamp_tier 1)" {} +
+    find "$dir" -name 'configure'  -exec touch -t "$(autotools_stamp_tier 2)" {} +
     find "$dir" \( -name 'config.h.in' -o -name 'config.hin' -o -name '*.h.in' \) \
-        -exec touch -t 202001010003 {} +
-    find "$dir" -name 'Makefile.in'  -exec touch -t 202001010004 {} +
+        -exec touch -t "$(autotools_stamp_tier 3)" {} +
+    find "$dir" -name 'Makefile.in' -exec touch -t "$(autotools_stamp_tier 4)" {} +
 }
 
 # Function to download all libraries

--- a/native/build-config.sh
+++ b/native/build-config.sh
@@ -241,14 +241,20 @@ normalize_autotools_timestamps() {
     # mirror the autotools dependency graph, so a new file class must be inserted
     # at the tier its dependencies require, not appended.
     #
-    #   0 sources (configure.ac/Makefile.am/m4)
-    #   1 aclocal.m4      depends on tier 0
-    #   2 configure       depends on tiers 0-1
-    #   3 config.h.in     depends on tiers 0-1, and must not predate configure
-    #   4 Makefile.in     depends on tiers 0-1
-    find "$dir" \( -name 'configure.ac' -o -name 'configure.in' -o -name 'Makefile.am' \
-        -o \( -name '*.m4' -a ! -name 'aclocal.m4' \) \) \
-        -exec touch -t "$(autotools_stamp_tier 0)" {} +
+    #   0 every input       the whole tree, see below
+    #   1 aclocal.m4        depends on tier 0
+    #   2 configure         depends on tiers 0-1
+    #   3 config.h.in       depends on tiers 0-1, and must not predate configure
+    #   4 Makefile.in       depends on tiers 0-1
+    #
+    # Tier 0 deliberately backdates the entire tree rather than an enumerated list of
+    # source patterns. automake makes Makefile.in depend on every fragment that
+    # Makefile.am includes, and those are not named predictably - xz's
+    # src/liblzma/Makefile.am pulls in seven */Makefile.inc files, none of which match
+    # a configure.ac/Makefile.am/*.m4 pattern. Missing one silently lets the rebuild
+    # rule fire and reintroduces the host-automake dependency. Backdating everything
+    # first means no input can outrank a generated file, whatever the package includes.
+    find "$dir" -exec touch -t "$(autotools_stamp_tier 0)" {} +
     find "$dir" -name 'aclocal.m4' -exec touch -t "$(autotools_stamp_tier 1)" {} +
     find "$dir" -name 'configure'  -exec touch -t "$(autotools_stamp_tier 2)" {} +
     find "$dir" \( -name 'config.h.in' -o -name 'config.hin' -o -name '*.h.in' \) \

--- a/native/build-config.sh
+++ b/native/build-config.sh
@@ -206,6 +206,40 @@ download_toolchain() {
     echo "$cache_file"
 }
 
+# Normalise autotools timestamps for a freshly unpacked release tarball.
+#
+# Release tarballs ship a complete, self-consistent set of generated files
+# (aclocal.m4, configure, config.h.in, Makefile.in, build-aux/ltmain.sh). If their
+# mtimes are out of dependency order, make fires the autotools rebuild rules and
+# demands the exact tool versions the tarball was built with - e.g.
+# "automake-1.17: command not found".
+#
+# Rewriting the files instead (aclocal && automake && autoconf) is worse: it
+# regenerates aclocal.m4 from the *host* libtool.m4 while leaving the tarball's
+# ltmain.sh in place, so a host libtool newer than the tarball's fails with
+# "libtool: Version mismatch error ... definition of this LT_INIT comes from".
+#
+# Stamping the files in dependency order keeps the tarball's own generated files
+# and stops any rebuild rule from firing, so neither the host automake version
+# nor the host libtool version can affect the build.
+normalize_autotools_timestamps() {
+    local dir="$1"
+    [ -d "$dir" ] || return 0
+    [ -f "$dir/configure" ] || return 0
+
+    echo "Normalising autotools timestamps in ${dir}..."
+
+    # Oldest -> newest, matching the autotools dependency graph:
+    #   configure.ac/Makefile.am/m4 -> aclocal.m4 -> configure -> config.h.in -> Makefile.in
+    find "$dir" \( -name 'configure.ac' -o -name 'configure.in' -o -name 'Makefile.am' \
+        -o \( -name '*.m4' -a ! -name 'aclocal.m4' \) \) -exec touch -t 202001010000 {} +
+    find "$dir" -name 'aclocal.m4'  -exec touch -t 202001010001 {} +
+    find "$dir" -name 'configure'   -exec touch -t 202001010002 {} +
+    find "$dir" \( -name 'config.h.in' -o -name 'config.hin' -o -name '*.h.in' \) \
+        -exec touch -t 202001010003 {} +
+    find "$dir" -name 'Makefile.in'  -exec touch -t 202001010004 {} +
+}
+
 # Function to download all libraries
 # Always unpacks fresh copies from cache
 download_all_libraries() {
@@ -218,15 +252,14 @@ download_all_libraries() {
     download_library "$ZLIB_URL" "zlib" "zlib-${ZLIB_VERSION}" "$ZLIB_SHA256"
     download_library "$XZ_URL" "xz" "xz-${XZ_VERSION}" "$XZ_SHA256"
 
-    # Fix xz automake timestamp issue - touch generated files to prevent regeneration
-    # xz 5.8.2 was built with automake 1.18.1 which may not be available on build systems
-    if [ -d "xz-${XZ_VERSION}" ]; then
-        echo "Fixing xz automake timestamps..."
-        find "xz-${XZ_VERSION}" -name "configure" -exec touch {} \;
-        find "xz-${XZ_VERSION}" -name "Makefile.in" -exec touch {} \;
-        find "xz-${XZ_VERSION}" -name "aclocal.m4" -exec touch {} \;
-        find "xz-${XZ_VERSION}" -name "config.h.in" -exec touch {} \;
-    fi
+    # Stop autotools rebuild rules firing in any unpacked tarball. Without this the
+    # build depends on the host's automake/libtool versions matching the ones each
+    # tarball was released with, which breaks whenever a runner image updates them.
+    # libxml2 is excluded: it is built via its own autogen.sh, which deliberately
+    # runs a full, self-consistent autoreconf (libtoolize included).
+    normalize_autotools_timestamps "libarchive-${LIBARCHIVE_VERSION}"
+    normalize_autotools_timestamps "xz-${XZ_VERSION}"
+    normalize_autotools_timestamps "lzo-${LZO_VERSION}"
 }
 
 # Detect number of CPU cores

--- a/native/build-macos.sh
+++ b/native/build-macos.sh
@@ -58,8 +58,8 @@ cd ..
 
 echo "Building xz ${XZ_VERSION}..."
 cd xz-${XZ_VERSION}
-# Regenerate autotools files for local automake version
-aclocal && automake && autoconf
+# No autotools regeneration here: the tarball ships consistent generated files and
+# download_all_libraries has already stamped them in dependency order.
 ./configure --cache-file=$(get_config_cache darwin-universal) --with-pic --disable-shared --prefix=$PREFIX
 make -sj$NCPU install
 cd ..
@@ -75,8 +75,9 @@ make -j$NCPU -sC zstd-${ZSTD_VERSION} install
 
 echo "Building libarchive ${LIBARCHIVE_VERSION}..."
 cd libarchive-${LIBARCHIVE_VERSION}
-# Regenerate autotools files for local automake version
-aclocal && automake && autoconf
+# No autotools regeneration here: running aclocal would rebuild aclocal.m4 from the
+# host's libtool.m4 while leaving the tarball's older ltmain.sh in place, which fails
+# with "libtool: Version mismatch error" once the runner's libtool outpaces it.
 export LIBXML2_PC_CFLAGS=-I$PREFIX/include/libxml2
 export LIBXML2_PC_LIBS="-L$PREFIX -lxml2"
 ./configure --cache-file=$(get_config_cache darwin-universal) --prefix=$PREFIX --enable-silent-rules --disable-dependency-tracking --enable-static --disable-shared --disable-bsdtar --disable-bsdcat --disable-bsdcpio --disable-rpath --enable-posix-regex-lib=libc --enable-xattr --enable-acl --enable-largefile --with-pic --with-zlib --with-bz2lib --with-libb2 --with-iconv --with-lz4 --with-zstd --with-lzma --with-lzo2 --with-cng

--- a/native/build-macos.sh
+++ b/native/build-macos.sh
@@ -18,15 +18,15 @@ cd "$BUILD_DIR"
 # Load shared configuration
 . "${SCRIPT_DIR}/build-config.sh"
 
-# Ensure build tools are available
+# Ensure build tools are available (libxml2's autogen.sh runs autoreconf)
 echo "Installing required build tools..."
 brew install autoconf automake libtool 2>/dev/null || true
 
-# Create symlinks for automake-1.17 (xz 5.8+ was built with this version)
-# Homebrew installs automake 1.18+ but xz's build system looks for version-specific commands
-BREW_PREFIX="$(brew --prefix)"
-ln -sf "${BREW_PREFIX}/bin/automake" "${BREW_PREFIX}/bin/automake-1.17"
-ln -sf "${BREW_PREFIX}/bin/aclocal" "${BREW_PREFIX}/bin/aclocal-1.17"
+# No automake-1.17/aclocal-1.17 symlinks: nothing invokes a version-specific
+# automake now that the tarballs' generated files are left in place. Such a
+# symlink would also be actively harmful, letting an aclocal.m4 rebuild rule
+# silently regenerate aclocal.m4 from the host libtool.m4 and reintroduce the
+# "libtool: Version mismatch error" this stamping is meant to prevent.
 
 # macOS-specific build settings
 export CPPFLAGS="-I$PREFIX/include"


### PR DESCRIPTION
Every open PR has been failing the same `Build MacOS dylib` job since early August, which gates the Linux/Windows/test jobs (they show as `skipping`). One root cause, not five.

## Failure

```
libtool: Version mismatch error.  This is libtool 2.5.4 Debian-2.5.4-4, but
libtool: the definition of this LT_INIT comes from libtool 2.6.2.
make[1]: *** [libarchive/archive_acl.lo] Error 63
```

`build-macos.sh` ran `aclocal && automake && autoconf` before configuring xz and libarchive. `aclocal` rewrites `aclocal.m4` from the **host** `libtool.m4` but leaves the tarball’s `build/autoconf/ltmain.sh` alone, so the generated `libtool` script and the `LT_INIT` macro come from different libtool releases.

That stayed benign while the runner’s libtool matched the tarball’s 2.5.4. It broke the moment Homebrew moved to 2.6.2 — which is why all five open PRs started failing simultaneously without any of them touching the native build. The build workflow only runs on PR branches, so `main` never surfaced it.

## Why the regeneration existed

It was guarding a real problem, so this doesn’t just delete it. These tarballs ship files generated by a specific automake; if mtimes fall out of dependency order, make fires the autotools rebuild rules and demands the exact tool version:

```
build/autoconf/missing: line 85: automake-1.17: command not found
make: *** [Makefile.in] Error 1
```

Regenerating avoided that but traded it for the libtool coupling above.

## Fix

Stamp the generated files in dependency order instead, so no rebuild rule fires at all:

```
configure.ac/Makefile.am/m4 -> aclocal.m4 -> configure -> config.h.in -> Makefile.in
```

The tarball’s own generated files are kept and stay mutually consistent, so **neither the host automake version nor the host libtool version can affect the build** — the class of breakage goes away rather than moving.

This also replaces the previous xz-only timestamp workaround, which touched files in the wrong order (leaving `aclocal.m4` newer than `configure` and `Makefile.in`) and only worked because the four `touch` calls usually landed within the same second.

`libxml2` is deliberately excluded: it is built via its own `autogen.sh`, a full self-consistent `autoreconf` that refreshes `ltmain.sh` too.

## Verification

Run locally on macOS against the real tarballs:

- Reproduced `Error 63` by putting 2.6.2 `LT_INIT` macros over the tarball’s 2.5.4 `ltmain.sh` — confirms the root cause.
- Reproduced the `automake-1.17: command not found` path from timestamp skew — confirms the regeneration’s original purpose is still needed.
- With the fix, built from a **worst-case-skewed** tree (`aclocal.m4`/`configure.ac` forced newest): configure and make succeed with **0** rebuild rules fired, and `aclocal.m4`/`ltmain.sh` both remain the tarball’s own 2.5.4.
- Validated for both **3.8.8** (current `main`) and **3.8.9** (#261) — 3.8.9 ships the same 2.5.4 `ltmain.sh`, so it would hit the identical failure.

`shellcheck` findings unchanged versus `main` (34 → 34, none in the new code); `pre-commit` passes.

Note my local libtool is 2.5.4, so the local runs cannot exercise the 2.6.2 mismatch directly — CI on this PR is the real end-to-end check.

## Follow-up

The five open PRs (#255, #261, #264, #265, #266) need rebasing onto `main` once this lands to pick up the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents macOS dylib failures by removing `libtool` version coupling and deflakes a progress reporting test. Previously we regenerated autotools files and created `automake-1.17` symlinks (mixing host `libtool.m4` with tarball `ltmain.sh`) and used async `Progress<T>` in tests; now we keep tarball-generated files, stamp timestamps to block rebuild rules, drop the symlinks, and use a synchronous `IProgress` in the test.

- Add normalize_autotools_timestamps with explicit tiers (via autotools_stamp_tier) that backdate the whole tree, then stamp aclocal.m4 → configure → config.h.in → Makefile.in; applied to libarchive, xz, and lzo; exclude libxml2 (built via its own autogen.sh).
- Remove `aclocal && automake && autoconf` for xz/libarchive in the macOS build and delete `automake-1.17`/`aclocal-1.17` symlink creation.
- Replace racy `Progress<T>` usage in WriterTests with an inline SynchronousProgress to make assertions deterministic.

**Rollout**
- Build/test-only change; no runtime impact.
- Rebase open PRs onto main after merge to restore macOS CI.

<sup>Written for commit 099770c35184cb6040d62b29dacdb2c9f582929b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jas88/libarchive.net/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

