### PR TITLE
Stamp symlinks themselves rather than their targets

### DIFF
--- a/native/build-config.sh
+++ b/native/build-config.sh
@@ -254,12 +254,18 @@ normalize_autotools_timestamps() {
     # a configure.ac/Makefile.am/*.m4 pattern. Missing one silently lets the rebuild
     # rule fire and reintroduces the host-automake dependency. Backdating everything
     # first means no input can outrank a generated file, whatever the package includes.
-    find "$dir" -exec touch -t "$(autotools_stamp_tier 0)" {} +
-    find "$dir" -name 'aclocal.m4' -exec touch -t "$(autotools_stamp_tier 1)" {} +
-    find "$dir" -name 'configure'  -exec touch -t "$(autotools_stamp_tier 2)" {} +
+    #
+    # touch -h stamps a symlink itself rather than its target. find does not follow
+    # symlinks while walking, but touch dereferences by default, so without -h a
+    # symlink pointing out of the tree would silently backdate a file elsewhere on the
+    # system. None of the tarballs currently ship symlinks; -h keeps that from becoming
+    # a problem if one ever does.
+    find "$dir" -exec touch -h -t "$(autotools_stamp_tier 0)" {} +
+    find "$dir" -name 'aclocal.m4' -exec touch -h -t "$(autotools_stamp_tier 1)" {} +
+    find "$dir" -name 'configure'  -exec touch -h -t "$(autotools_stamp_tier 2)" {} +
     find "$dir" \( -name 'config.h.in' -o -name 'config.hin' -o -name '*.h.in' \) \
-        -exec touch -t "$(autotools_stamp_tier 3)" {} +
-    find "$dir" -name 'Makefile.in' -exec touch -t "$(autotools_stamp_tier 4)" {} +
+        -exec touch -h -t "$(autotools_stamp_tier 3)" {} +
+    find "$dir" -name 'Makefile.in' -exec touch -h -t "$(autotools_stamp_tier 4)" {} +
 }
 
 # Function to download all libraries


### PR DESCRIPTION
Follow-up to #267, addressing a review comment on the timestamp stamping added there.

## Issue

`find` does not follow symlinks while walking, but `touch` dereferences by default. The tier-0 whole-tree stamp therefore rewrote the mtime of whatever a symlink *pointed at* — and for a symlink pointing out of the extracted tree, that means silently backdating an unrelated file elsewhere on the system.

## Validity

Real mechanism, but **latent rather than active**. Reproduced directly:

| | external file mtime after stamping |
|---|---|
| plain `touch` | `2026-06-01` → **`2020-01-01`** (clobbered) |
| `touch -h` | `2026-06-01` (untouched) |

However, none of the tarballs this function stamps ship any symlink entries at all:

```
libarchive-3.8.8.tar.xz     0 symlink entries
libarchive-3.8.9.tar.xz     0 symlink entries
xz-5.8.3.tar.xz             0 symlink entries
lzo-2.10.tar.gz             0 symlink entries
```

So nothing is affected today. `-h` costs nothing and keeps a future tarball from turning this into a real problem, which is why it is worth applying now rather than leaving as a trap.

## Verification

- Escaping symlink: with `-h` the target keeps its mtime and the symlink itself is stamped; without `-h` the target is clobbered.
- Portability: `-h` accepted by both BSD `touch` (macOS runner) and GNU coreutils `touch` 9.11 (Linux runner), with GNU verified to preserve the external target.
- No regression in the actual purpose: xz still builds with `automake`, `aclocal`, `autoconf`, `autoheader`, `autoreconf` and `libtoolize` all replaced by shims that `exit 1`, i.e. no rebuild rule fires.
- Full native macOS build: 0 `missing`-mediated autotools invocations, 0 libtool mismatches, byte-identical dylib (6,051,504 bytes).

`shellcheck` findings unchanged (34, none in the changed code).

## Not changed

The review also suggested not backdating directories. Directory mtimes do not participate in the autotools rebuild rules this guards, so excluding them would add complexity without changing behaviour.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stamp symlinks themselves during autotools timestamp normalization to avoid touching targets. Previously the tier-0 sweep dereferenced symlinks with touch, which could backdate files outside the extracted tree; now `-h` stamps the link node.

- Adds `-h` to all `touch` calls in tiers 0–4.
- Portability verified on BSD and GNU `touch` (macOS/Linux).
- No current impact (tarballs contain no symlinks); rebuild-rule suppression unchanged; no migration.

<sup>Written for commit 3a6446c2bfe3fd5caa2b3d0dbe93935f0db08473. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jas88/libarchive.net/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

